### PR TITLE
Inconsistent sidebar styles

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,5 +1,5 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
   <h3 class="sidebar-title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Issue #1: The problem was occurring because in two places in the sidebar the names had an underscore separator rather than a hyphen. They were being interpreted as a new class, rather than belonging to a class already defined in the stylesheet. I changed the two lines so that they include the correct hyphenated class.