### PR TITLE
#1 Inconsistent Sidebar Styles

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,5 +1,5 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>


### PR DESCRIPTION
This fixes issue #1 Inconsistent Sidebar Styles

The title for the "Archives" section in the sidebar was a different style than the others because of an inconsistent use of classes.  An underscore was used instead of a dash on line 2 in _content.html.erb.


![screen shot 2017-03-31 at 10 46 16 am](https://cloud.githubusercontent.com/assets/17444630/24562367/68358322-15ff-11e7-87ce-e64340e1b0c3.png)
 