### PR TITLE
Fixes sf-wdi-35/publify-debugging-lab#6 by adding null checking

### DIFF
--- a/publify_core/app/helpers/base_helper.rb
+++ b/publify_core/app/helpers/base_helper.rb
@@ -168,6 +168,7 @@ module BaseHelper
   end
 
   def display_date_and_time(timestamp)
+    return "<no time>" if timestamp.nil?
     if this_blog.date_format == 'setting_date_format_distance_of_time_in_words'
       timeago_tag timestamp, date_only: false
     else

--- a/publify_core/app/models/article.rb
+++ b/publify_core/app/models/article.rb
@@ -93,6 +93,7 @@ class Article < Content
 
   # FIXME: Use keyword params to clean up call sites.
   def permalink_url(anchor = nil, only_path = false)
+    return "" unless published
     @cached_permalink_url ||= {}
     @cached_permalink_url["#{anchor}#{only_path}"] ||= blog.url_for(permalink_url_options, anchor: anchor, only_path: only_path)
   end


### PR DESCRIPTION
Adds checks for unpublished articles so that previews display correctly, and format of the page is preserved, to fix #6.