### PR TITLE
corrected class names in archives_sidebar/_content.html.erb 

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Issue #1 

Corrected class names on <div> and <h3> in archives_sidebar/_content.html.erb from 'sidebar_title' and 'sidebar_body' to 'sidebar-title' and 'sidebar-body'.