### PR TITLE
Fixes #1 - Inconsistent Sidebar Styles

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
This fixes issue #1 - Inconsistent Sidebar Styles.

Problem: The styling for Archives sidebar section was different from the other sidebar styling in the page. This was due to incorrect naming of the class of the h3 and div sections of the Archives sidebar.

Solution: The h3 class "sidebar_title" was corrected to "sidebar-title", and the div class "sidebar_body" was corrected to "sidebar-body". This matches the classes of the other sidebars which allows the styling to also match.