### PR TITLE
Fixes #1 - Sidebar_styles_archive

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,5 +1,5 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
   <h3 class="sidebar-title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
This Fixes #1 - Inconsistent Sidebar Styles

Archive in Sidebar was not rendering properly. 

Fixed a "_" to a "-" in LINE:2 /publify_core/app/views/archives_sidebar/_content.html.erb
                          AND  LINE:5 /publify_core/app/views/archives_sidebar/_content.html.erb

It was generating the wrong css class for Sidebar Title and Sidebar Body. It needed to be sidebar-title and sidebar-body for the proper CSS rule to apply.