### PR TITLE
Fixes #3 - Load spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix load spinner
+
 ### Breaking/large changes
 
 * Break out Publify functionality into several engines. These engines will
@@ -404,4 +406,3 @@ platform][4].
 [2]: http://t37.net/is-coding-a-blogging-engine-still-worth-the-effort-in-2013-and-other-thoughts-about-content-publishing-tools.html
 [3]: https://github.com/publify/typographic
 [4]: http://demo.publify.co/
-

--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
   $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $('form.spinnable').on('ajax:complete', function(evt, xhr, status){ $('#spinner').hide();})
 });


### PR DESCRIPTION
Missing .hide() method in index.js.erb, that's why it wasn't going away even after the ajax call is done