### PR TITLE
removed modulo from articles month count

### DIFF
--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i % 12) + 1
+      month = entry.month.to_i
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
Issue #4 

removed "% 12" and "+1" from archives_sidebar.rb, because it wasn't doing anything.

 