### PR TITLE
Fixes Issue #2, tags being saved as 'object'

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
#2  In the save_article_tags function, the value of the input field (#article_keywords) is being set to an input element (with name hidden-article[keywords]) rather than the value of that element. I added a .val() to get that value.