### PR TITLE
Fix sidebar styles

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,5 +1,5 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>

--- a/themes/bootstrap-2/stylesheets/style.css
+++ b/themes/bootstrap-2/stylesheets/style.css
@@ -2,6 +2,9 @@ body {
   background: #edece3;
 }
 
+h3 {
+  font-family: inherit;
+}
 /* Page header classes */
 .navbar {
   border-radius: 0;
@@ -83,5 +86,6 @@ body {
 }
 
 #sidebar .sidebar-body li {
-  list-style-type: circle;
+  list-style-type: block;
 }
+


### PR DESCRIPTION
This closes #1.

Issue: All titles in the sidebar should have monospace style font

- Solution:
I fixed this by changing class "sidebar_title" to "sidebar-title"

Issue: All bullets should be unfilled circles.

- Solution:
I fixed this by changing the bullet points style from circle to block to be consistent with other lists in the sidebar 
