### PR TITLE
select value of hidden-article keywords for tags

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,8 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
+
 }
 
 function doneTyping () {


### PR DESCRIPTION
Fixed #2 - Posts Tags Are Shown As Object 

Solution: I fixed this by modifying the publify_admin.js file's function "Save Article Tags" to select the value of the article form's hidden article's keywords. Prior, it was returning the entire object, not selecting the values within the object.

```
function save_article_tags() {
  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
}
```