### PR TITLE
Fixes Issues #2 - Post Tags Are Shown As Objects

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,5 +1,5 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
   <div class="sidebar_body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
   <h3 class="sidebar-title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Issues #2 

Post tags were showing up as Objects because publify_admin.js#save_article_tags wasn't being set to the value of keywords, but to the keywords Object.

I added a .val() to the end of the find function in line#79.