### PR TITLE
Side bar styles fixed

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
In publify-debugging-lab/publify_core/app/views/archives_sidebar/_content.html.erb:
Changed HTML classes "side_title" and "side_body" to match CSS classes "side-title" and side-body"
(please reference issue https://github.com/sf-wdi-35/publify-debugging-lab/issues/1)