### PR TITLE
Fixes #3, spinner hideson ajax:complete

### DIFF
--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
   $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $('form.spinnable').on('ajax:complete', function(evt, xhr, status){ $('#spinner').hide();})
 });


### PR DESCRIPTION
Changed spinner actions so that the ajax status that triggered hide action is ajax:complete.