### PR TITLE
post tags fixed

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
In publify_core/app/assets/javascripts/publify_admin.js:
Added `.val()` to display the value of the tags instead of the tag
(please reference issue https://github.com/sf-wdi-35/publify-debugging-lab/issues/2)