### PR TITLE
Fixed Issue #2 - post tags are shown as "object"

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
Issue #2 - post tags are shown as "object"

Solution - adding the .val() method to the save_article_tags function allows us to find the value of the object saved (the keyword) instead of finding the whole object.