### PR TITLE
Fixed Issue #3 - Load spinner does not go away

### DIFF
--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
   $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $('form.spinnable').on('ajax:success', function(evt, xhr, status){ $('#spinner').hide();})
 });


### PR DESCRIPTION
Issue #3 - Load spinner does not go away

Solution: ajax:after does not work. It does not exist. ajax:success works.