### PR TITLE
Issue #2 - Tags Now Display Correctly

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
Fixes #2 

The save_article_tags method in the publify_admin.js file was grabbing tags from the input fields as objects rather than as that object's value.  Calling value on the end of the line ensure that the correct value is passed from the form to the database.