### PR TITLE
spinner issue fixed

### DIFF
--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
   $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $('form.spinnable').on('ajax:success', function(evt, xhr, status){ $('#spinner').hide();})
 });


### PR DESCRIPTION
On publify_core/app/assets/javascripts/spinnable.js:
`ajax:after` is not a command. changed to `ajax:success`
(please reference issue https://github.com/sf-wdi-35/publify-debugging-lab/issues/3)