### PR TITLE
removed modulo + 1 to fix article month show + order

### DIFF
--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i % 12) + 1
+      month = entry.month.to_i
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
Fixed #4 and #5: 

Removing % 12  + 1 because that operation messes with the order of the months showing up in the article archives and articles showing up for selected month. 